### PR TITLE
Fixed how vehicle color vector is calculated

### DIFF
--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -57,7 +57,7 @@ void Graphics::drawTrafficObjects()
             cv::RNG rng(it->getID());
             int b = rng.uniform(0, 255);
             int g = rng.uniform(0, 255);
-            int r = sqrt(255*255 - g*g - r*r); // ensure that length of color vector is always 255
+            int r = sqrt(255*255 - g*g - b*b); // ensure that length of color vector is always 255
             cv::Scalar vehicleColor = cv::Scalar(b,g,r);
             cv::circle(_images.at(1), cv::Point2d(posx, posy), 50, vehicleColor, -1);
         }


### PR DESCRIPTION
When number of vehicles is set to one color of the vehicle is changing rapidly. This is due to the error in how vehicle color is calculated. 