### PR TITLE
Correct project name in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11.3)
 
 # set(CMAKE_CXX_STANDARD 17)
-project(OSM_A_star_search)
+project(traffic_simulation)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -pthread")
 
 find_package(OpenCV 4.1 REQUIRED)


### PR DESCRIPTION
I've corrected the "project" option in the CMake file by changing it from "OSM_A_star_search" to "traffic_simulation". Some IDEs like CLion show this name, when f.e. hovering over a minimized window, which leads to confusion, when multiple CLion windows are open at the same time.