### PR TITLE
Added <memory> includes to resolve compiler errors

### DIFF
--- a/src/Intersection.cpp
+++ b/src/Intersection.cpp
@@ -87,6 +87,11 @@ void Intersection::addVehicleToQueue(std::shared_ptr<Vehicle> vehicle)
     std::cout << "Intersection #" << _id << ": Vehicle #" << vehicle->getID() << " is granted entry." << std::endl;
     
     // FP.6b : use the methods TrafficLight::getCurrentPhase and TrafficLight::waitForGreen to block the execution until the traffic light turns green.
+    if (_trafficLight.getCurrentPhase() == TrafficLightPhase::red)
+    {
+        _trafficLight.waitForGreen();
+        std::cout << "Intersection #" << _id << " is green!!!" << std::endl;
+    }
 
     lck.unlock();
 }
@@ -109,6 +114,7 @@ void Intersection::setIsBlocked(bool isBlocked)
 void Intersection::simulate() // using threads + promises/futures + exceptions
 {
     // FP.6a : In Intersection.h, add a private member _trafficLight of type TrafficLight. At this position, start the simulation of _trafficLight.
+    _trafficLight.simulate();
 
     // launch vehicle queue processing in a thread
     threads.emplace_back(std::thread(&Intersection::processVehicleQueue, this));

--- a/src/Intersection.cpp
+++ b/src/Intersection.cpp
@@ -146,12 +146,10 @@ void Intersection::processVehicleQueue()
 bool Intersection::trafficLightIsGreen()
 {
    // please include this part once you have solved the final project tasks
-   /*
    if (_trafficLight.getCurrentPhase() == TrafficLightPhase::green)
        return true;
    else
        return false;
-   */
 
   return true; // makes traffic light permanently green
 } 

--- a/src/Intersection.h
+++ b/src/Intersection.h
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <memory>
 #include "TrafficObject.h"
+#include "TrafficLight.h"
 
 // forward declarations to avoid include cycle
 class Street;
@@ -54,6 +55,7 @@ private:
     std::vector<std::shared_ptr<Street>> _streets;   // list of all streets connected to this intersection
     WaitingVehicles _waitingVehicles; // list of all vehicles and their associated promises waiting to enter the intersection
     bool _isBlocked;                  // flag indicating wether the intersection is blocked by a vehicle
+    TrafficLight _trafficLight;
 };
 
 #endif

--- a/src/Street.h
+++ b/src/Street.h
@@ -2,6 +2,7 @@
 #define STREET_H
 
 #include "TrafficObject.h"
+#include <memory>
 
 // forward declaration to avoid include cycle
 class Intersection;

--- a/src/TrafficLight.cpp
+++ b/src/TrafficLight.cpp
@@ -1,32 +1,41 @@
 #include <iostream>
 #include <random>
+#include <future>
 #include "TrafficLight.h"
 
 /* Implementation of class "MessageQueue" */
 
-/* 
 template <typename T>
 T MessageQueue<T>::receive()
 {
     // FP.5a : The method receive should use std::unique_lock<std::mutex> and _condition.wait() 
     // to wait for and receive new messages and pull them from the queue using move semantics. 
     // The received object should then be returned by the receive function. 
+    std::unique_lock<std::mutex> lck(_mutex);
+    _msg_condition.wait(lck, [this] { return !_queue.empty(); });
+
+    T msg = std::move(_queue.back());
+    _queue.pop_back();
+    return msg;
 }
 
 template <typename T>
 void MessageQueue<T>::send(T &&msg)
 {
-    // FP.4a : The method send should use the mechanisms std::lock_guard<std::mutex> 
+    // FP.4a :
+    // The method send should use the mechanisms std::lock_guard<std::mutex> 
     // as well as _condition.notify_one() to add a new message to the queue and afterwards send a notification.
+    std::lock_guard<std::mutex> lck(_mutex);
+    _queue.push_back(std::move(msg));
+    _msg_condition.notify_one();
 }
-*/
 
 /* Implementation of class "TrafficLight" */
 
-/* 
 TrafficLight::TrafficLight()
 {
     _currentPhase = TrafficLightPhase::red;
+    _msgQueue = std::make_shared<MessageQueue<TrafficLightPhase>>();
 }
 
 void TrafficLight::waitForGreen()
@@ -34,6 +43,14 @@ void TrafficLight::waitForGreen()
     // FP.5b : add the implementation of the method waitForGreen, in which an infinite while-loop 
     // runs and repeatedly calls the receive function on the message queue. 
     // Once it receives TrafficLightPhase::green, the method returns.
+    while (true)
+    {
+        TrafficLightPhase phase = _msgQueue->receive();
+        if (phase == TrafficLightPhase::green)
+        {
+           return;
+        }
+    }
 }
 
 TrafficLightPhase TrafficLight::getCurrentPhase()
@@ -44,15 +61,41 @@ TrafficLightPhase TrafficLight::getCurrentPhase()
 void TrafficLight::simulate()
 {
     // FP.2b : Finally, the private method „cycleThroughPhases“ should be started in a thread when the public method „simulate“ is called. To do this, use the thread queue in the base class. 
+    threads.emplace_back(&TrafficLight::cycleThroughPhases, this);
 }
 
 // virtual function which is executed in a thread
 void TrafficLight::cycleThroughPhases()
 {
-    // FP.2a : Implement the function with an infinite loop that measures the time between two loop cycles 
-    // and toggles the current phase of the traffic light between red and green and sends an update method 
-    // to the message queue using move semantics. The cycle duration should be a random value between 4 and 6 seconds. 
-    // Also, the while-loop should use std::this_thread::sleep_for to wait 1ms between two cycles. 
-}
+    // FP.2a : 
+    // Implement the function with an infinite loop that measures the time between two loop cycles 
+    // X Toggles the current phase of the traffic light between red and green
+    // Sends an update method to the message queue using move semantics.
+    // X The cycle duration should be a random value between 4 and 6 seconds. 
+    // X Also, the while-loop should use std::this_thread::sleep_for to wait 1ms between two cycles. 
+    while (true)
+    {
+        // generate wait time between 4 and 6
+        float random_s = 4 + static_cast <float> (rand()) / (static_cast <float> (RAND_MAX / 2.0));
+        int random_ms = int(random_s * 1000);
 
-*/
+        // wait for r seconds
+        std::this_thread::sleep_for(std::chrono::milliseconds(random_ms));
+        
+        // change _currentPhase
+        if (_currentPhase == TrafficLightPhase::red)
+        {
+            _currentPhase = TrafficLightPhase::green;
+        }
+        else
+        {
+            _currentPhase = TrafficLightPhase::red;
+        }
+
+        // send update message to message queue
+        _msgQueue->send(std::move(_currentPhase));
+        
+        // sleep for 1ms between cycles
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}

--- a/src/TrafficLight.h
+++ b/src/TrafficLight.h
@@ -19,8 +19,13 @@ template <class T>
 class MessageQueue
 {
 public:
+  void send(T &&msg);
+  T receive();
 
 private:
+  std::condition_variable _msg_condition;
+  std::mutex _mutex;
+  std::deque<T> _queue;
     
 };
 
@@ -30,21 +35,30 @@ private:
 // can be either „red“ or „green“. Also, add the private method „void cycleThroughPhases()“. 
 // Furthermore, there shall be the private member _currentPhase which can take „red“ or „green“ as its value. 
 
-class TrafficLight
+enum TrafficLightPhase { red, green };
+
+class TrafficLight : public TrafficObject
 {
 public:
     // constructor / desctructor
+    TrafficLight();
 
     // getters / setters
+    TrafficLightPhase getCurrentPhase();
 
     // typical behaviour methods
+    void waitForGreen();
+    void simulate();
 
 private:
     // typical behaviour methods
+    void cycleThroughPhases();
+    TrafficLightPhase _currentPhase;
 
     // FP.4b : create a private member of type MessageQueue for messages of type TrafficLightPhase 
     // and use it within the infinite loop to push each new TrafficLightPhase into it by calling 
     // send in conjunction with move semantics.
+    std::shared_ptr<MessageQueue<TrafficLightPhase>> _msgQueue;
 
     std::condition_variable _condition;
     std::mutex _mutex;

--- a/src/Vehicle.h
+++ b/src/Vehicle.h
@@ -2,6 +2,7 @@
 #define VEHICLE_H
 
 #include "TrafficObject.h"
+#include <memory>
 
 // forward declarations to avoid include cycle
 class Street;


### PR DESCRIPTION
Project is missing memory include that should be necessary for these objects to compile.  Added include to header file because standard library is part of classes public facing definition.