### PR TITLE
Add <memory> header

### DIFF
--- a/src/Street.h
+++ b/src/Street.h
@@ -2,6 +2,7 @@
 #define STREET_H
 
 #include "TrafficObject.h"
+#include <memory>
 
 // forward declaration to avoid include cycle
 class Intersection;

--- a/src/Vehicle.h
+++ b/src/Vehicle.h
@@ -2,6 +2,7 @@
 #define VEHICLE_H
 
 #include "TrafficObject.h"
+#include <memory>
 
 // forward declarations to avoid include cycle
 class Street;


### PR DESCRIPTION
The as-is code is not buildable on my machine. It lacks including the `<memory>` header to get the `std::enable_shared_from_this` function to compile in `Vehicle.h` and `Street.h`.